### PR TITLE
Removed .conf and baseline_version dependencies

### DIFF
--- a/Azure/Azure-Templatized-YML-Pipeline/flyway-9.22.3/deploy-cherrypick.yml
+++ b/Azure/Azure-Templatized-YML-Pipeline/flyway-9.22.3/deploy-cherrypick.yml
@@ -22,7 +22,7 @@ variables:
   # $(System.DefaultWorkingDirectory)\project
   # The default is to have the migrations folder in the same directory as the yml file
   WORKING_DIRECTORY: $(System.DefaultWorkingDirectory)
-  FLYWAY: 'flyway -user="$(userName)" -password="$(password)" -baselineOnMigrate=true -errorOverrides=S0001:0:I- -baselineVersion=$(BASELINE_VERSION) -licenseKey=$(FLYWAY_LICENSE_KEY) -configFiles="$(WORKING_DIRECTORY)\flyway.conf"'
+  FLYWAY: 'flyway -user="$(userName)" -password="$(password)" -baselineOnMigrate=true -errorOverrides=S0001:0:I- -licenseKey=$(FLYWAY_LICENSE_KEY)'
   BUILD_NAME: 'Repository-Snapshot'
   RELEASE_PREVIEW: 'Release-Preview.sql'
   DRIFT_AND_CHANGE_REPORT: 'Drift-And-Change-Report.html'


### PR DESCRIPTION
config file should be in working directory so autodiscoverable, baseline version should be in the config file rather than defined at the pipeline level