### PR TITLE
Updated to support Licence Permits

### DIFF
--- a/Azure/installFlyway.yml
+++ b/Azure/installFlyway.yml
@@ -1,5 +1,5 @@
 parameters:
-- name: version
+- name: flywayversion
   type: string
   default: '9.21.1'
 - name: edition
@@ -8,30 +8,28 @@ parameters:
   values:
     - community
     - teams
-- name: platform
+- name: sqlfluffversion
   type: string
-  default: windows
-  values:
-    - windows
-    - macosx
-    - linux
-
+  default: '3.0.7'
 
 steps:
 - task: PowerShell@2
   displayName: 'Download and unzip Flyway command line'
   env:
     FLYWAY_LICENSE_KEY: $(FLYWAY_LICENSE_KEY)
-    FLYWAY_VERSION: ${{ parameters.version }}
-    FLYWAY_PLATFORM: ${{ parameters.platform }}
+    FLYWAY_VERSION: ${{ parameters.flywayversion }}
+    FLYWAY_EDITION: ${{ parameters.edition }}
   inputs:
     targetType: 'inline'    
     script: |
       # Write your PowerShell commands here.
       $version = $env:FLYWAY_VERSION
-      $platform = $env:FLYWAY_PLATFORM
-      $extension = $platform -eq 'windows' ? 'zip' : 'tar.gz' 
-      Write-Host "Hello Flyway Enterprise, getting Version $version for $platform"
+      $edition = $env:FLYWAY_EDITION
+      $extension = $IsWindows ? 'zip' : 'tar.gz' 
+      if ($IsWindows) {$platform = 'windows'}`
+      elseif ($IsMacOS) {$platform = 'macosx'}`
+      elseif ($IsLinux) {$platform = 'linux'}
+      Write-Host "Hello Flyway $edition, getting Version $version for $platform"
       $flywayZip = "https://download.red-gate.com/maven/release/org/flywaydb/enterprise/flyway-commandline/$version/flyway-commandline-$version-$platform-x64.$extension" 
       $targetZip = "flyway-commandline-$version-$platform-x64.$extension"
       $flyway = "flyway-$version"
@@ -39,7 +37,7 @@ steps:
       mkdir ./Tools
       # Remove-Item .\Tools -Force -Recurse -ErrorAction Ignore
       Invoke-WebRequest $flywayZip -OutFile $targetZip
-      if ($platform -eq 'windows')
+      if ($IsWindows)
       {
         Expand-Archive -LiteralPath $targetZip -DestinationPath ./Tools
       }
@@ -51,6 +49,13 @@ steps:
       write-host "##vso[task.prependpath]$flywayPath"
     pwsh: true
     workingDirectory: '$(Pipeline.Workspace)'
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install sqlfluff==${{ parameters.sqlfluffversion }}
+  displayName: 'Install SQL Fluff'
+  failOnStderr: true
+
 - task: PowerShell@2
   displayName: 'Check Flyway Client'
   continueOnError: true

--- a/Azure/installFlyway.yml
+++ b/Azure/installFlyway.yml
@@ -1,35 +1,56 @@
 parameters:
 - name: flywayversion
   type: string
-  default: '9.21.1'
-- name: edition
+  default: '11.0.0'
+- name: licenseType
   type: string
-  default: community
+  default: Community
   values:
-    - community
-    - teams
+    - LicenseKey
+    - LicensePermit
+    - Community
 - name: sqlfluffversion
   type: string
   default: '3.0.7'
 
+# Make sure one of the following variables is defined when using a licensed copy of Flyway
+#
+# If using LicenseKey as your license type make sure the variable FLYWAY_LICENSE_KEY is defined
+# in the redgate-global-vars variable group
+#
+# If using LicensePermit as your license type, make sure you upload your permit file as a Secure File
+# into your Library and named REDGATE_LICENSING_PERMIT
+# For more information about the Redgate Permit File see the following article https://documentation.red-gate.com/fd/license-permits-224919672.html
+#
+
+
 steps:
+- task: DownloadSecureFile@1
+  name: REDGATE_LICENSING_PERMIT
+  condition: ${{ eq(parameters.licenseType, 'LicensePermit')}}
+  displayName: 'Download Flyway License Permit'
+  inputs:
+    secureFile: 'REDGATE_LICENSING_PERMIT'
+
 - task: PowerShell@2
   displayName: 'Download and unzip Flyway command line'
   env:
     FLYWAY_LICENSE_KEY: $(FLYWAY_LICENSE_KEY)
+    REDGATE_LICENSING_PERMIT_PATH: $(redgate_licensing_permit.secureFilePath)
     FLYWAY_VERSION: ${{ parameters.flywayversion }}
-    FLYWAY_EDITION: ${{ parameters.edition }}
+    LICENSE_TYPE: ${{ parameters.licenseType }}
   inputs:
     targetType: 'inline'    
     script: |
       # Write your PowerShell commands here.
       $version = $env:FLYWAY_VERSION
-      $edition = $env:FLYWAY_EDITION
+      $licenseType = $env:LICENSE_TYPE
+      $permitFilePath = $env:REDGATE_LICENSING_PERMIT_PATH
       $extension = $IsWindows ? 'zip' : 'tar.gz' 
       if ($IsWindows) {$platform = 'windows'}`
       elseif ($IsMacOS) {$platform = 'macosx'}`
       elseif ($IsLinux) {$platform = 'linux'}
-      Write-Host "Hello Flyway $edition, getting Version $version for $platform"
+      Write-Host "Hello Flyway, getting Version $version for $platform"
       $flywayZip = "https://download.red-gate.com/maven/release/org/flywaydb/enterprise/flyway-commandline/$version/flyway-commandline-$version-$platform-x64.$extension" 
       $targetZip = "flyway-commandline-$version-$platform-x64.$extension"
       $flyway = "flyway-$version"
@@ -45,6 +66,15 @@ steps:
       {
         tar -xvf $targetZip -C ./Tools
         chmod +x $flywayPath/flyway
+      }
+      if ($licenseType -eq 'LicensePermit')
+      {
+         if (Test-Path -Path $permitFilePath -PathType leaf)
+         {
+           $permitFile = Split-Path -Path $permitFilePath
+           Move-Item -Path $permitFile -Destination $flywayPath/flyway/$permitFile
+           write-host "##vso[task.setvariable variable=REDGATE_LICENSING_PERMIT_PATH;]$flywayPath/flyway/$permitFile"
+         } 
       }      
       write-host "##vso[task.prependpath]$flywayPath"
     pwsh: true
@@ -57,14 +87,44 @@ steps:
   failOnStderr: true
 
 - task: PowerShell@2
-  displayName: 'Check Flyway Client'
+  displayName: 'Check Flyway Client (Community)'
+  condition: ${{ eq(parameters.licenseType, 'Community')}}
   continueOnError: true
-  env:
-    #FLYWAY_LICENSE_KEY: $(FLYWAY_LICENSE_KEY)
-    FLYWAY_EDITION: ${{ parameters.edition }}
   inputs:
    targetType: 'inline'
    script: |  
+     $Env:FLYWAY_LICENSE_KEY = ''
+     $Env:REDGATE_LICENSING_PERMIT_PATH = ''
+     write-host "$($env:PATH)"
+     flyway -v
+   pwsh: true
+   failOnStderr: false
+
+- task: PowerShell@2
+  displayName: 'Check Flyway Client (Licensed)'
+  condition: ${{ eq(parameters.licenseType, 'LicenseKey')}}
+  continueOnError: true
+  env:
+    FLYWAY_LICENSE_KEY: $(FLYWAY_LICENSE_KEY)
+  inputs:
+   targetType: 'inline'
+   script: |  
+     $Env:REDGATE_LICENSING_PERMIT_PATH = ''
+     write-host "$($env:PATH)"
+     flyway -v
+   pwsh: true
+   failOnStderr: false
+
+- task: PowerShell@2
+  displayName: 'Check Flyway Client (Licensed)'
+  condition: ${{ eq(parameters.licenseType, 'LicensePermit')}}
+  continueOnError: true
+  env:
+    REDGATE_LICENSING_PERMIT_PATH: $(REDGATE_LICENSING_PERMIT_PATH)
+  inputs:
+   targetType: 'inline'
+   script: |  
+     $Env:FLYWAY_LICENSE_KEY = ''
      write-host "$($env:PATH)"
      flyway -v
    pwsh: true

--- a/Azure/installFlyway.yml
+++ b/Azure/installFlyway.yml
@@ -19,24 +19,24 @@ parameters:
 # in the redgate-global-vars variable group
 #
 # If using LicensePermit as your license type, make sure you upload your permit file as a Secure File
-# into your Library and named REDGATE_LICENSING_PERMIT
+# into your Library and named REDGATE_LICENSING_PERMIT.txt
 # For more information about the Redgate Permit File see the following article https://documentation.red-gate.com/fd/license-permits-224919672.html
 #
 
 
 steps:
 - task: DownloadSecureFile@1
-  name: REDGATE_LICENSING_PERMIT
+  name: LicensePermitFile
   condition: ${{ eq(parameters.licenseType, 'LicensePermit')}}
   displayName: 'Download Flyway License Permit'
   inputs:
-    secureFile: 'REDGATE_LICENSING_PERMIT'
+    secureFile: 'REDGATE_LICENSING_PERMIT.txt'
 
 - task: PowerShell@2
   displayName: 'Download and unzip Flyway command line'
   env:
     FLYWAY_LICENSE_KEY: $(FLYWAY_LICENSE_KEY)
-    REDGATE_LICENSING_PERMIT_PATH: $(redgate_licensing_permit.secureFilePath)
+    LICENSING_PERMIT_PATH: $(LicensePermitFile.secureFilePath)
     FLYWAY_VERSION: ${{ parameters.flywayversion }}
     LICENSE_TYPE: ${{ parameters.licenseType }}
   inputs:
@@ -45,7 +45,7 @@ steps:
       # Write your PowerShell commands here.
       $version = $env:FLYWAY_VERSION
       $licenseType = $env:LICENSE_TYPE
-      $permitFilePath = $env:REDGATE_LICENSING_PERMIT_PATH
+      $permitFilePath = $env:LICENSING_PERMIT_PATH
       $extension = $IsWindows ? 'zip' : 'tar.gz' 
       if ($IsWindows) {$platform = 'windows'}`
       elseif ($IsMacOS) {$platform = 'macosx'}`
@@ -71,10 +71,19 @@ steps:
       {
          if (Test-Path -Path $permitFilePath -PathType leaf)
          {
-           $permitFile = Split-Path -Path $permitFilePath
-           Move-Item -Path $permitFile -Destination $flywayPath/flyway/$permitFile
-           write-host "##vso[task.setvariable variable=REDGATE_LICENSING_PERMIT_PATH;]$flywayPath/flyway/$permitFile"
+           write-host "Permit File Path: $permitFilePath"
+           $permitFile = Split-Path -Path $permitFilePath -Leaf
+           Move-Item -Path $permitFilePath -Destination $flywayPath/$permitFile
+           write-host "##vso[task.setvariable variable=REDGATE_LICENSING_PERMIT_PATH;]$flywayPath/$permitFile"
          } 
+         else
+         {
+           write-host "File $permitFilePath does not exist"
+         }
+      }
+      else
+      {
+        write-host "skipping permit license file"
       }      
       write-host "##vso[task.prependpath]$flywayPath"
     pwsh: true
@@ -95,7 +104,7 @@ steps:
    script: |  
      $Env:FLYWAY_LICENSE_KEY = ''
      $Env:REDGATE_LICENSING_PERMIT_PATH = ''
-     write-host "$($env:PATH)"
+     write-host "PATH = $($env:PATH)"
      flyway -v
    pwsh: true
    failOnStderr: false
@@ -110,7 +119,8 @@ steps:
    targetType: 'inline'
    script: |  
      $Env:REDGATE_LICENSING_PERMIT_PATH = ''
-     write-host "$($env:PATH)"
+     write-host "PATH = $($env:PATH)"
+     write-host "FLYWAY_LICENSE_KEY = $($env:FLYWAY_LICENSE_KEY)"
      flyway -v
    pwsh: true
    failOnStderr: false
@@ -125,7 +135,8 @@ steps:
    targetType: 'inline'
    script: |  
      $Env:FLYWAY_LICENSE_KEY = ''
-     write-host "$($env:PATH)"
+     write-host "PATH = $($env:PATH)"
+     write-host "REDGATE_LICENSING_PERMIT_PATH = $($env:REDGATE_LICENSING_PERMIT_PATH)"
      flyway -v
    pwsh: true
    failOnStderr: false


### PR DESCRIPTION
Using the Flyway License Key is now considered Legacy, the new method introduced in v10 and the first to be checked when launching Flyway Cli is the Permit File Location set in Environment Variable. Please see the comments in the template for creating the Secure File in Azure Pipelines Library.

The License Type of Community (free) is set to be the default in the step template.